### PR TITLE
Add HTML build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,11 @@ tutorials/W1D4_Paleoclimate/euro2k_data
 *.lpd
 *.icloud
 .climatematch
+
+# Generated HTML files from Jupyter notebooks (to prevent large repository size)
+tutorials/**/*.html
+projects/**/*.html
+
+# Generated HTML files from Jupyter notebooks (to prevent large repository size)
+tutorials/**/*.html
+projects/**/*.html

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,3 @@ tutorials/W1D4_Paleoclimate/euro2k_data
 tutorials/**/*.html
 projects/**/*.html
 
-# Generated HTML files from Jupyter notebooks (to prevent large repository size)
-tutorials/**/*.html
-projects/**/*.html


### PR DESCRIPTION
## Problem
The repository's `.git` folder is currently 1.4 GB, with approximately 2.2 GB of HTML files stored in git history. These HTML files are generated build artifacts from Jupyter notebooks and should not be tracked in version control.

## Analysis
Using `git rev-list --objects --all` analysis, I found:
- **8,277 HTML file versions** exist in git history
- Primary locations:
  - `tutorials/` directory: **2.0 GB** (6,713 files)
  - `projects/` directory: **139 MB** (1,061 files)
  - `book/_build/` directory: already in `.gitignore` ✓

These are generated HTML files from Jupyter notebooks that can be rebuilt from source.

## Changes
This PR adds patterns to `.gitignore` to prevent future HTML files from being committed:
- `tutorials/**/*.html` - Generated tutorial HTML files
- `projects/**/*.html` - Generated project HTML files

## Note
This PR does **not** remove existing HTML files from git history (which would require history rewriting with tools like `git-filter-repo` or BFG Repo-Cleaner and coordinated force-push). This is a **preventive measure** for future commits only.

To reduce the repository size, please decide whether to:
1. Rewrite history to remove HTML files (breaking change for existing clones)
2. Use `git filter-repo --path-glob '*.html' --invert-paths` to clean history
3. Archive the current repository and start fresh